### PR TITLE
Display datetimes in the Confluence site's configured formatting

### DIFF
--- a/src/main/resources/templates/email.vm
+++ b/src/main/resources/templates/email.vm
@@ -1,3 +1,4 @@
+#set( $dateFormatter = $action.getDateFormatter())
 Email adresses of users who <b>$signedOrNot</b> <i>$signature.getTitle()</i> ( $signature.getHash() )<br/>
 <label for="withNames" >With names</label>
 <input type="checkbox" $withNamesChecked onclick="location.href='$toggleWithNamesURL'" id="withNames" value="withNames">
@@ -10,4 +11,4 @@ $email
 #end
 </pre>
 
-<!-- generated $date.format("dd.MM.yyyy HH:mm",$currentDate) -->
+<!-- generated $dateFormatter.formatDateTime($currentDate) -->

--- a/src/main/resources/templates/export.vm
+++ b/src/main/resources/templates/export.vm
@@ -1,3 +1,4 @@
+#set( $dateFormatter = $action.getDateFormatter())
 <style type="text/css">
 body {
 padding: 2% 4% 2% 4%;
@@ -14,7 +15,7 @@ padding-right: 12px;
   	#set( $userName =  $date2userName.key)
   	#set( $profile =  $profiles.get($userName))
 	<tr>
-		<td>$date.format("yyyy.MM.dd hh:ss",$date2userName.value)</td>
+		<td>$dateFormatter.formatDateTime($date2userName.value)</td>
 		<td>$profile.getFullName()</td>
 		<td>$profile.getEmail()</td>
 	</tr>
@@ -27,4 +28,4 @@ padding-right: 12px;
 	</tr>
 #end
 </table>
-<!-- generated $date.format("dd.MM.yyyy HH:mm",$currentDate) -->
+<!-- generated $dateFormatter.formatDateTime($currentDate) -->

--- a/src/main/resources/templates/macro.vm
+++ b/src/main/resources/templates/macro.vm
@@ -1,3 +1,4 @@
+#set( $dateFormatter = $action.getDateFormatter())
 #set( $title =  $signature.getTitle())
 #if( $panel )
 <div class="panel" style="border-width: 1px;">
@@ -32,7 +33,7 @@
   	#foreach ($date2userName in $orderedSignatures)
   	    #set( $userName =  $date2userName.key)
   	    #set( $profile =  $profiles.get($userName))
-	    <li><input class="checkbox" type="checkbox" checked="checked" disabled="true"> $date.format("dd.MM.yyyy HH:mm",$date2userName.value) - <a href="mailto:$profile.getEmail()">$profile.getFullName()</a></li>
+	    <li><input class="checkbox" type="checkbox" checked="checked" disabled="true"> $dateFormatter.formatDateTime($date2userName.value) - <a href="mailto:$profile.getEmail()">$profile.getFullName()</a></li>
 	#end
 	#foreach( $profile in $orderedMissingSignatureProfiles)
 	    <li style="color: #bbb;"><input class="checkbox" type="checkbox" disabled="true"> $profile.getFullName()</li>


### PR DESCRIPTION
Confluence site administrators may set date and time formatting under General Configuration > Formatting and International Settings. This PR causes the date and time of a signature to be displayed using these configured formats instead of the previous hardcoded `yyyy.MM.dd hh:ss` format.