### PR TITLE
#44: Version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.classpath
 /.project
 /target
+
+.idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk11
+  - openjdk11
 script: mvn package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 script: mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.baloise.confluence</groupId>
     <artifactId>digital-signature</artifactId>
-    <version>0.10.2</version>
+    <version>7.0.0</version>
+
     <organization>
         <name>Baloise</name>
         <url>http://www.baloise.ch/</url>
     </organization>
+
+    <name>digital-signature</name>
+    <description>This is the com.baloise.confluence:digital-signature plugin for Atlassian Confluence.</description>
+    <packaging>atlassian-plugin</packaging>
+
     <issueManagement>
         <system>Github</system>
         <url>https://github.com/baloise/digital-signature/issues</url>
@@ -18,57 +27,63 @@
         <developerConnection>scm:git:https://github.com/baloise/digital-signature.git</developerConnection>
         <url>https://github.com/baloise/digital-signature.git</url>
     </scm>
-    <name>digital-signature</name>
-    <description>This is the com.baloise.confluence:digital-signature plugin for Atlassian Confluence.</description>
-    <packaging>atlassian-plugin</packaging>
+
     <dependencies>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark</artifactId>
-            <version>0.32.18</version>
+            <version>0.60.2</version>
         </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence</artifactId>
             <version>${confluence.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>com.atlassian.mywork</groupId>
             <artifactId>mywork-api</artifactId>
             <version>1.0.2</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-annotation</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
             <scope>compile</scope>
         </dependency>
+
         <dependency>
             <groupId>com.atlassian.plugin</groupId>
             <artifactId>atlassian-spring-scanner-runtime</artifactId>
             <version>${atlassian.spring.scanner.version}</version>
             <scope>runtime</scope>
         </dependency>
+
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.8.0-alpha2</version>
+            <version>2.0.0-alpha1</version>
             <scope>test</scope>
         </dependency>
+
         <!-- WIRED TEST RUNNER DEPENDENCIES -->
         <dependency>
             <groupId>com.atlassian.plugins</groupId>
@@ -88,29 +103,35 @@
             <version>2.2.2-atlassian-1</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>
-                <artifactId>maven-confluence-plugin</artifactId>
+                <artifactId>confluence-maven-plugin</artifactId>
                 <version>${amps.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <productVersion>${confluence.version}</productVersion>
                     <productDataVersion>${confluence.data.version}</productDataVersion>
                     <enableQuickReload>true</enableQuickReload>
-                    <enableFastdev>false</enableFastdev>
                     <instructions>
                         <Atlassian-Plugin-Key>${atlassian.plugin.key}</Atlassian-Plugin-Key>
                         <!-- Add package to export here -->
-                        <Export-Package>com.baloise.confluence.digitalsignature.api,</Export-Package>
+                        <Export-Package>com.baloise.confluence.digitalsignature.api</Export-Package>
                         <!-- Add package import here -->
-                        <Import-Package>org.springframework.osgi.*;resolution:="optional", org.eclipse.gemini.blueprint.*;resolution:="optional", *</Import-Package>
-                        <!-- Ensure plugin is spring powered - see https://extranet.atlassian.com/x/xBS9hQ -->
+                        <Import-Package>
+                            org.springframework.osgi.*;resolution:="optional",
+                            org.eclipse.gemini.blueprint.*;resolution:="optional",
+                            *
+                        </Import-Package>
+
+                        <!-- Ensure plugin is spring powered -->
                         <Spring-Context>*</Spring-Context>
                     </instructions>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>com.atlassian.plugin</groupId>
                 <artifactId>atlassian-spring-scanner-maven-plugin</artifactId>
@@ -135,18 +156,20 @@
             </plugin>
         </plugins>
     </build>
+
     <properties>
-        <confluence.version>6.6.0</confluence.version>
-        <confluence.data.version>6.6.0</confluence.data.version>
-        <amps.version>6.3.14</amps.version>
-        <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
+        <confluence.version>6.14.0</confluence.version>
+        <confluence.data.version>6.14.0</confluence.data.version>
+        <amps.version>8.0.2</amps.version>
+        <plugin.testrunner.version>2.0.1</plugin.testrunner.version>
         <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
+        <!-- This property ensures consistency between the key in atlassian-plugin.xml and the OSGi bundle's key. -->
+        <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
-        
     </properties>
+
     <repositories>
         <repository>
             <releases>
@@ -177,6 +200,7 @@
             <url>https://maven.atlassian.com/repository/public</url>
         </pluginRepository>
     </pluginRepositories>
+
     <profiles>
         <profile>
             <id>travis</id>
@@ -218,4 +242,5 @@
             </build>
         </profile>
     </profiles>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>confluence</artifactId>
             <version>${confluence.version}</version>
             <scope>provided</scope>
-        </dependency>
+       </dependency>
 
         <dependency>
             <groupId>com.atlassian.mywork</groupId>
@@ -168,6 +168,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
     <repositories>
@@ -182,7 +183,7 @@
                 <checksumPolicy>warn</checksumPolicy>
             </snapshots>
             <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/repository/public</url>
+            <url>https://packages.atlassian.com/mvn/maven-external/</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -197,7 +198,7 @@
                 <checksumPolicy>warn</checksumPolicy>
             </snapshots>
             <id>atlassian-public</id>
-            <url>https://maven.atlassian.com/repository/public</url>
+            <url>https://packages.atlassian.com/mvn/maven-external/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/src/main/java/com/baloise/confluence/digitalsignature/Markdown.java
+++ b/src/main/java/com/baloise/confluence/digitalsignature/Markdown.java
@@ -2,24 +2,23 @@ package com.baloise.confluence.digitalsignature;
 
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.util.options.MutableDataSet;
+import com.vladsch.flexmark.util.data.MutableDataSet;
 
 public class Markdown {
-	
-	private Parser parser;
-	private HtmlRenderer renderer;
 
-	public Markdown() {
-		MutableDataSet options = new MutableDataSet();
-		options.set(HtmlRenderer.DO_NOT_RENDER_LINKS, true);
-		options.set(HtmlRenderer.ESCAPE_HTML, true);
-		
-		parser = Parser.builder(options).build();
-		renderer = HtmlRenderer.builder(options).build();
-	}
+    private Parser parser;
+    private HtmlRenderer renderer;
 
-	public String toHTML(String markdown) {
-		return renderer.render(parser.parse(markdown));
-	}
+    public Markdown() {
+        MutableDataSet options = new MutableDataSet();
+        options.set(HtmlRenderer.DO_NOT_RENDER_LINKS, true);
+        options.set(HtmlRenderer.ESCAPE_HTML, true);
 
+        parser = Parser.builder(options).build();
+        renderer = HtmlRenderer.builder(options).build();
+    }
+
+    public String toHTML(String markdown) {
+        return renderer.render(parser.parse(markdown));
+    }
 }


### PR DESCRIPTION
Regenerated and Rebuilt using
- https://adoptopenjdk.net/releases.html (javac -version, 1.8.0_242)
- https://developer.atlassian.com/server/framework/atlassian-sdk/install-the-atlassian-sdk-on-a-windows-system/ (atlas-version, 8.0.16)

Atlassian SDK 8.0.16 supports:
- Jira Server 7.6.1 - 8.2.1,
- Confluence Server 6.14.0 - 7.1.2,
- Fisheye/Crucible 4.6.1,
- Bamboo Server 6.2.1 - 6.9.2,
- Crowd 2.9.1 - 3.4.6,
- Bitbucket Server 5.6.0 - 6.10.22019-06-12

New project was generated using following command:
`atlas-create-confluence-plugin --non-interactive -a digital-signature -g com.baloise.confluence -v 7.0.0`

The resulting POM was than used to update the one in this PR.
