### PR TITLE
compile gson library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.2.2-atlassian-1</version>
-			<scope>provided</scope>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -212,6 +212,9 @@
 				<version>${amps.version}</version>
 				<extensions>true</extensions>
 				<configuration>
+					<banningExcludes>
+						<exclude>com.google.code.gson:gson</exclude>
+					</banningExcludes>
 					<productVersion>${confluence.version}</productVersion>
 					<enableQuickReload>true</enableQuickReload>
 


### PR DESCRIPTION
As mentioned in issue #119 the gson library is internal only on Confluence DC and not available for export to plugins.
This solved it for me and it'll activate. The recommended "fat.jar" that included the gson library stopped working on the latest patches.